### PR TITLE
Link to a fork with electron-edge-js

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ screenshot(0, // 0 is for active window
     });
  ```
  
+# Electron
+
+Check out [Tomas Hubelbauer's fork](https://github.com/TomasHubelbauer/window-screenshot).
  
 # Todo
  


### PR DESCRIPTION
Hello, I've forked your project and replaced Edge with `electron-edge-js` which comes with prebuilt binaries, so it's possible to just use out of the box unlike Edge which makes you build your own first. Please consider linking to it so that people can use both depending on their scenario.